### PR TITLE
Python2 compatability, _add_methods and png generation

### DIFF
--- a/ipymol/core.py
+++ b/ipymol/core.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import time
 import tempfile
-import xmlrpc.client as xc
 import threading
 import numpy as np
 import warnings

--- a/ipymol/core.py
+++ b/ipymol/core.py
@@ -61,10 +61,10 @@ class MolViewer(object):
         fig = plt.figure(figsize=(20, 20))
         ax = fig.add_subplot(111)
         ax.axis('off')
-        png_filename = 'tmp_png_file_for_ipymol' + '.png'
-        self._server.do("cmd.png('%s')" % png_filename )
-        ax.imshow(mpimg.imread(png_filename))
-        os.remove(png_filename)
+        fh = tempfile.NamedTemporaryFile()
+        self._server.do("cmd.png('%s')" % fh.name)
+        ax.imshow(mpimg.imread(fh.name))
+        os.close(fh)
         return fig
 
 # Create a default instance for convenience

--- a/ipymol/core.py
+++ b/ipymol/core.py
@@ -26,9 +26,6 @@ class MolViewer(object):
         )
         self._thread.daemon = True
 
-        if hasattr(self, '_server'):
-            self._add_methods()
-
     def _add_methods(self):
         for method in self._server.system.listMethods():
             if method[0].islower():
@@ -42,6 +39,16 @@ class MolViewer(object):
         self._server = Server(
             uri="http://%s:%d/RPC2" % (self.host, self.port)
         )
+
+        # check if the server is online yet, then add methods
+        server_online = False
+        while not server_online:
+            try:
+                if hasattr(self, '_server'):
+                    self._add_methods()
+                server_online = True
+            except:
+                pass
 
     def display(self):
         """Display PyMol session using matplotlib

--- a/ipymol/core.py
+++ b/ipymol/core.py
@@ -7,6 +7,7 @@ import threading
 import numpy as np
 import warnings
 import matplotlib.pyplot as plt
+import matplotlib.image as mpimg
 
 from .compat import Image, Server
 
@@ -53,7 +54,10 @@ class MolViewer(object):
         fig = plt.figure(figsize=(20, 20))
         ax = fig.add_subplot(111)
         ax.axis('off')
-        ax.imshow(np.asarray(self.to_png()))
+        png_filename = 'tmp_png_file_for_ipymol' + '.png'
+        self._server.do("cmd.png('%s')" % png_filename )
+        ax.imshow(mpimg.imread(png_filename))
+        os.remove(png_filename)
         return fig
 
 # Create a default instance for convenience


### PR DESCRIPTION
Hi,

First of all, thanks for sharing! I'm using Python 2.7, the unused xmlrpc import statement caused an ImportError. 

There's no to_png() method in my instance, I also couldn't find one in the PyMol docs so I rewrote it, generating a temporary png file which is deleted after showing the picture. Am I missing something here?

The first issue addressed in https://github.com/cxhernandez/ipymol/issues/14 hints that _add_methods() does not execute properly. It used to be called from  __init__, i.e. before start() is run. I moved it to start(). Unfortunately, xmlrpclib.Server does not wait until it's finished. Therefore, the next line might be run before the server is up and running. This results in an error. To avoid that, I added the while loop around the try-except. 

I checked that there's no to_png() method even after calling _add_methods() successfully.

Best,
Niklas