### PR TITLE
modernize MolViewer

### DIFF
--- a/ipymol/core.py
+++ b/ipymol/core.py
@@ -1,10 +1,9 @@
 from __future__ import print_function
 
 import os
+import time
 import tempfile
-import threading
-import matplotlib.pyplot as plt
-import matplotlib.image as mpimg
+import subprocess
 
 from .compat import Server
 
@@ -16,54 +15,93 @@ class MolViewer(object):
     def __init__(self, host=HOST, port=PORT):
         self.host = host
         self.port = int(port)
-        self._thread = threading.Thread(
-            target=os.system,
-            args=(('pymol -RQ', )),
-        )
-        self._thread.daemon = True
+        self._process = None
+
+    def __del__(self):
+        self.stop()
 
     def __getattr__(self, key):
+        if not self._process_is_running():
+            self.start(["-cKQ"])
+
         return getattr(self._server, key)
 
-    def _add_methods(self):
-        for method in self._server.system.listMethods():
-            if method[0].islower():
-                setattr(self, method, getattr(self._server, method))
+    def _process_is_running(self):
+        return self._process is not None and self._process.poll() is None
 
-    def start(self):
-        if self._thread.is_alive():
+    def start(self, args=("-Q",), exe="pymol"):
+        """Start the PyMOL RPC server and connect to it
+
+        Start simple GUI (-xi), suppress all output (-Q):
+
+            >>> viewer.start(["-xiQ"])
+
+        Start headless (-cK), with some output (-q):
+
+            >>> viewer.start(["-cKq"])
+
+        """
+        if self._process_is_running():
             print("A PyMOL RPC server is already running.")
             return
-        self._thread.start()
+
+        assert isinstance(args, (list, tuple))
+
+        self._process = subprocess.Popen([exe, "-R"] + list(args))
+
         self._server = Server(uri="http://%s:%d/RPC2" % (self.host, self.port))
 
-        # check if the server is online yet, then add methods
-        server_online = False
-        while not server_online:
+        # wait for the server
+        while True:
             try:
-                if hasattr(self, '_server'):
-                    self._add_methods()
-                server_online = True
-            except BaseException:
-                pass
-        self._add_methods()
+                self._server.bg_color('white')
+                break
+            except IOError:
+                time.sleep(0.1)
 
-    def display(self):
-        """Display PyMol session using matplotlib
+    def stop(self):
+        if self._process_is_running():
+            self._process.terminate()
+
+    def display(self, ray=0):
+        """Display PyMol session
 
         Returns
         -------
-        fig : matplotlib.pyplot.figure
+        fig : IPython.display.Image
 
         """
-        fig = plt.figure(figsize=(20, 20))
-        ax = fig.add_subplot(111)
-        ax.axis('off')
-        fh = tempfile.NamedTemporaryFile(suffix='.png')
-        self._server.do(f'png {fh.name};')
-        ax.imshow(mpimg.imread(fh.name))
-        os.close(fh)
-        return fig
+        from IPython.display import Image
+        from IPython.display import display
+        from ipywidgets import IntProgress
+
+        progress = None
+        filename = tempfile.mktemp('.png')
+
+        try:
+            self._server.png(filename, 0, 0, -1, int(ray))
+
+            # ~2min timeout
+            for i in range(1, 50):
+                if os.path.exists(filename):
+                    break
+
+                if progress is None:
+                    progress = IntProgress(min=0, max=50)
+                    display(progress)
+
+                progress.value += 1
+                time.sleep(i / 10.0)
+
+            return Image(filename)
+        finally:
+            if progress is not None:
+                progress.close()
+
+            try:
+                os.unlink(filename)
+            except:
+                pass
 
 
 # Create a default instance for convenience


### PR DESCRIPTION
- use `subprocess` instead of `os.system` thread
- automatically start headless server
- `stop()` method
- stop server if instance goes out of scope
- display: wait for image, show progress bar

Minimal example to show a ray traced image:
```python
from ipymol import viewer as pymol
pymol.fetch('3odu')
pymol.display()
```